### PR TITLE
Show eslint warnings in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,11 @@
     "**/node_modules": true
   },
   "editor.formatOnSave": true,
-  "prettier.eslintIntegration": true
+  "prettier.eslintIntegration": true,
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ]
 }


### PR DESCRIPTION
I found this setting when reading [this article](https://dev.to/robertcoopercode/using-eslint-and-prettier-in-a-typescript-project-53jb#automatically-fixing-code-vs-code) on how to autofix eslint in VSCode (different from autoFormat).

See also [vscode-eslint documentation](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint#user-content-settings-options)

Before:
Only ts warnings and errors show as Problems in VSCode

After:
eslint warnings and errors as shown also


<!--
Thanks for contributing!
Put an x in the checklist boxes that apply: [X]. You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [ ] Following [CODE_OF_CONDUCT.md](https://github.com/iamturns/create-exposed-app/blob/master/CODE_OF_CONDUCT.md).
- [ ] Checked for [duplicate pull requests](https://github.com/iamturns/create-exposed-app/pulls)
- [ ] Title is a summary of the change, in present tense, ideally < 50 characters
- [ ] Pulling from a branch (right side), not `master`.
- [ ] Pulling into `master` branch (left side).
- [ ] Fixing a bug? An open [bug report](https://github.com/iamturns/create-exposed-app/labels/bug) exists.
- [ ] Breaking API changes? Migration notes attached.

## :bug: Bug fix

...or...

## :sparkles: Enhancement

Closes #123, #456.

Describe your changes here. Possible details to include:

- Screenshots / gif demo
- What has changed?
- Why was it changed?
- Anything else changed to support the solution
- Anything unusual to point out
- Reasons for choosing this solution
- Alternative solutions considered